### PR TITLE
optimize string format

### DIFF
--- a/src/main/java/org/junit/runners/model/MultipleFailureException.java
+++ b/src/main/java/org/junit/runners/model/MultipleFailureException.java
@@ -34,7 +34,7 @@ public class MultipleFailureException extends Exception {
         StringBuilder sb = new StringBuilder(
                 String.format("There were %d errors:", fErrors.size()));
         for (Throwable e : fErrors) {
-            sb.append(String.format("\n  %s(%s)", e.getClass().getName(), e.getMessage()));
+            sb.append(String.format("%n  %s(%s)", e.getClass().getName(), e.getMessage()));
         }
         return sb.toString();
     }


### PR DESCRIPTION
 In format strings, it is generally preferable better to use %n, which will produce the platform-specific line separator.
